### PR TITLE
12 Get comments count for a single article endpoint complete

### DIFF
--- a/__tests__/endpoints/app.test.js
+++ b/__tests__/endpoints/app.test.js
@@ -69,7 +69,6 @@ describe("GET /api/articles/:article_id", () => {
       .expect(200)
       .then(({ body }) => {
         const { article } = body;
-        console.log("article :>> ", article);
         expect(article).toMatchObject({
           article_id: 1,
           title: "Living in the shadow of a great man",
@@ -93,7 +92,6 @@ describe("GET /api/articles/:article_id", () => {
       .expect(200)
       .then(({ body }) => {
         const { article } = body;
-        console.log("article :>> ", article);
         expect(article).toMatchObject({
           comments_count: 11,
         });

--- a/__tests__/endpoints/app.test.js
+++ b/__tests__/endpoints/app.test.js
@@ -79,7 +79,22 @@ describe("GET /api/articles/:article_id", () => {
           created_at: "2020-07-09T20:11:00.000Z",
           votes: 100,
           article_img_url:
-            "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+            "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        });
+      })
+      .catch((err) => {
+        res.status(err.status).send({ msg: err.msg });
+      });
+  });
+
+  test("status 200, return the object article", () => {
+    return request(app)
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({ body }) => {
+        const { article } = body;
+        console.log("article :>> ", article);
+        expect(article).toMatchObject({
           comments_count: 11,
         });
       })

--- a/__tests__/endpoints/app.test.js
+++ b/__tests__/endpoints/app.test.js
@@ -69,7 +69,7 @@ describe("GET /api/articles/:article_id", () => {
       .expect(200)
       .then(({ body }) => {
         const { article } = body;
-
+        console.log("article :>> ", article);
         expect(article).toMatchObject({
           article_id: 1,
           title: "Living in the shadow of a great man",
@@ -80,6 +80,7 @@ describe("GET /api/articles/:article_id", () => {
           votes: 100,
           article_img_url:
             "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          comments_count: 11,
         });
       })
       .catch((err) => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -38,7 +38,8 @@
         "body": "I find this existence challenging",
         "created_at": "2020-07-09T21:11:00.000Z",
         "votes": 100,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comments_count": 11
       }
     }
   },

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,8 +1,12 @@
 const db = require("../db/connection");
 
 exports.fetchArticle = (article_id) => {
-  let queryString = "SELECT * FROM articles WHERE article_id = $1";
-  return db.query(queryString + ";", [article_id]).then(({ rows }) => {
+  const queryString = `SELECT articles.*, CAST(COUNT(comments.article_id) AS INTEGER) AS comments_count FROM articles
+  JOIN comments ON articles.article_id = comments.article_id
+  WHERE articles.article_id = $1
+  GROUP BY articles.article_id`;
+
+  return db.query(queryString, [article_id]).then(({ rows }) => {
     if (rows.length === 0) {
       return Promise.reject({ status: 404, msg: "Not found" });
     } else {


### PR DESCRIPTION
Modify the query "get the article by its ID" to retrieve the amount of comments for that id
Tests keep working fine